### PR TITLE
Add .bat to ceylon if running in a Windows environment.

### DIFF
--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
@@ -43,7 +43,7 @@ class CeylonRunner {
                 println command
             } else {
                 log.info( "Running command: $command" )
-                def process = command.execute( [ ], project.file( '.' ) )
+                def process = command.execute( null, project.file( '.' ) )
 
                 consumeOutputOf process
 

--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
@@ -15,7 +15,8 @@ class CeylonToolLocator {
             return provided( configLocation )
         }
         List<String> options = ceylonHomeOptions() + sdkManOptions() + osOptions()
-        def ceylon = options.collect { new File( it ) }.find { it.file }
+        def ext = Os.isFamily( Os.FAMILY_WINDOWS ) ? ".bat" : ""
+        def ceylon = options.collect { new File( it + ext) }.find { it.file }
 
         if ( ceylon ) {
             return ceylon


### PR DESCRIPTION
On Windows, I was getting an error about ceylon not being executable because the .bat ext wasn't specified.
