### PR TITLE
Consume the output of the ceylon command process.

### DIFF
--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
@@ -11,6 +11,7 @@ class CeylonToolLocator {
         def ceylon = findCeylonLocation( configLocation )
         try {
             def process = ceylon.execute()
+            process.consumeProcessOutput(null, null)
             process.waitFor()
             return ceylon
         } catch ( IOException e ) {


### PR DESCRIPTION
Because the output of the ceylon command process isn't being consumed, the process.waitFor() hangs -- at least on Windows :).  See http://stackoverflow.com/questions/5483830/process-waitfor-never-returns
