### PR TITLE
Fixes #22 (Compilation Fails When Build Path Contains Whitespace)

### DIFF
--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonCommandOptions.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonCommandOptions.groovy
@@ -14,7 +14,7 @@ class CeylonCommandOptions {
         def options = [ ]
         def overrides = GenerateOverridesFileTask.overridesFile( project, config )
         if ( overrides.exists() ) {
-            options << "--overrides ${overrides.absolutePath}"
+            options << /--overrides "${overrides.absolutePath}"/
         } else {
             log.warn( 'The overrides.xml file could not be located: {}', overrides.absolutePath )
         }
@@ -27,8 +27,8 @@ class CeylonCommandOptions {
     }
 
     private static List getRepositoryOptions( Project project, CeylonConfig config ) {
-        [ "--rep=aether:${MavenSettingsFileCreator.mavenSettingsFile( project, config ).absolutePath}",
-          "--rep=${project.file( config.output ).absolutePath}" ]
+        [ /--rep="aether:${MavenSettingsFileCreator.mavenSettingsFile( project, config ).absolutePath}"/,
+          /--rep="${project.file( config.output ).absolutePath}"/ ]
     }
 
     private static File getOut( Project project, CeylonConfig config ) {
@@ -38,7 +38,7 @@ class CeylonCommandOptions {
     static List getTestCompileOptions( Project project, CeylonConfig config ) {
         def options = [ ]
 
-        options << "--out=${getOut( project, config ).absolutePath}"
+        options << /--out="${getOut( project, config ).absolutePath}"/
 
         config.testRoots.each { options << "--source $it" }
         config.testResourceRoots.each { options << "--resource $it" }
@@ -49,7 +49,7 @@ class CeylonCommandOptions {
     static List getCompileOptions( Project project, CeylonConfig config ) {
         def options = [ ]
 
-        options << "--out=${getOut( project, config ).absolutePath}"
+        options << /--out="${getOut( project, config ).absolutePath}"/
 
         config.sourceRoots.each { options << "--source $it" }
         config.resourceRoots.each { options << "--resource $it" }
@@ -80,8 +80,8 @@ class CeylonCommandOptions {
     static List getImportJarsOptions( Project project, CeylonConfig config, File moduleDescriptor ) {
         [ "${config.verbose ? '--verbose ' : ' '}",
           "${config.forceImports ? '--force ' : ' '}",
-          "--descriptor=${moduleDescriptor.absolutePath} ",
-          "--out=${getOut( project, config ).absolutePath}" ] +
+          /--descriptor="${moduleDescriptor.absolutePath}" /,
+          /--out="${getOut( project, config ).absolutePath}"/ ] +
                 getRepositoryOptions( project, config )
     }
 


### PR DESCRIPTION
In addition to the mentioned line in the issue, the error reappeared for other command line options, so I fixed every other absolute path in the file, too.