### PR TITLE
Add support for ceylon bootstrap wrappers

### DIFF
--- a/src/main/groovy/com/athaydes/gradle/ceylon/task/CreateJavaRuntimeTask.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/task/CreateJavaRuntimeTask.groovy
@@ -75,7 +75,7 @@ class CreateJavaRuntimeTask extends DefaultTask {
             throw new GradleException( "Unable to create Java runtime as directory can't be created: ${destination}" )
         }
 
-        CeylonRunner.withCeylon( config ) { String ceylon ->
+        CeylonRunner.withCeylon( config, project ) { String ceylon ->
             def options = CeylonCommandOptions.getCommonOptions( project, config, false )
 
             if ( project.hasProperty( 'get-ceylon-command' ) ) {

--- a/src/main/groovy/com/athaydes/gradle/ceylon/task/CreateJavaRuntimeTask.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/task/CreateJavaRuntimeTask.groovy
@@ -75,7 +75,7 @@ class CreateJavaRuntimeTask extends DefaultTask {
             throw new GradleException( "Unable to create Java runtime as directory can't be created: ${destination}" )
         }
 
-        CeylonRunner.withCeylon( config, project ) { String ceylon ->
+        CeylonRunner.withCeylon( project, config ) { String ceylon ->
             def options = CeylonCommandOptions.getCommonOptions( project, config, false )
 
             if ( project.hasProperty( 'get-ceylon-command' ) ) {

--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
@@ -12,8 +12,8 @@ class CeylonRunner {
 
     static final Logger log = Logging.getLogger( CeylonRunner )
 
-    static void withCeylon( CeylonConfig config, Project project, Closure<?> ceylonConsumer ) {
-        String ceylon = CeylonToolLocator.findCeylon( config.ceylonLocation, project )
+    static void withCeylon( Project project, CeylonConfig config, Closure<?> ceylonConsumer ) {
+        String ceylon = CeylonToolLocator.findCeylon( project, config.ceylonLocation )
         log.debug "Running Ceylon executable: ${ceylon}"
         try {
             ceylonConsumer ceylon
@@ -35,7 +35,7 @@ class CeylonRunner {
             ceylonArgs << project.property( 'ceylon-args' )?.toString()
         }
 
-        withCeylon( config, project ) { String ceylon ->
+        withCeylon( project, config ) { String ceylon ->
 
             if ( project.hasProperty( 'get-ceylon-command' ) ) {
                 def textFor = { List<String> list -> if ( list.empty ) '' else ' ' + list.join( ' ' ) }

--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonRunner.groovy
@@ -12,8 +12,8 @@ class CeylonRunner {
 
     static final Logger log = Logging.getLogger( CeylonRunner )
 
-    static void withCeylon( CeylonConfig config, Closure<?> ceylonConsumer ) {
-        String ceylon = CeylonToolLocator.findCeylon( config.ceylonLocation )
+    static void withCeylon( CeylonConfig config, Project project, Closure<?> ceylonConsumer ) {
+        String ceylon = CeylonToolLocator.findCeylon( config.ceylonLocation, project )
         log.debug "Running Ceylon executable: ${ceylon}"
         try {
             ceylonConsumer ceylon
@@ -35,7 +35,7 @@ class CeylonRunner {
             ceylonArgs << project.property( 'ceylon-args' )?.toString()
         }
 
-        withCeylon( config ) { String ceylon ->
+        withCeylon( config, project ) { String ceylon ->
 
             if ( project.hasProperty( 'get-ceylon-command' ) ) {
                 def textFor = { List<String> list -> if ( list.empty ) '' else ' ' + list.join( ' ' ) }

--- a/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
+++ b/src/main/groovy/com/athaydes/gradle/ceylon/util/CeylonToolLocator.groovy
@@ -7,8 +7,8 @@ import java.util.concurrent.Callable
 
 class CeylonToolLocator {
 
-    static String findCeylon( configLocation, project ) {
-        def ceylon = findCeylonLocation( configLocation, project )
+    static String findCeylon( project, configLocation ) {
+        def ceylon = findCeylonLocation( project, configLocation )
         try {
             def process = ceylon.execute()
             process.consumeProcessOutput()
@@ -22,7 +22,7 @@ class CeylonToolLocator {
         }
     }
 
-    private static String findCeylonLocation( configLocation, project ) {
+    private static String findCeylonLocation( project, configLocation ) {
         if ( configLocation ) {
             return provided( configLocation )
         }


### PR DESCRIPTION
Ceylon bootstrap follows the same concept as gradle wrappers and
once executed places ceylonb scripts in the project home. This has
the advantage that ceylon versions can easily be switched without
having to mess with actual system wide installations.